### PR TITLE
Update to match current lighttable API

### DIFF
--- a/src/lt/plugins/gitstatusbar.cljs
+++ b/src/lt/plugins/gitstatusbar.cljs
@@ -6,7 +6,7 @@
             [lt.objs.bottombar :as bottombar]
             [lt.objs.editor :as ed]
             [lt.objs.context :as ctx]
-            [lt.objs.statusbar :as statusbar]
+            [lt.objs.status_bar :as statusbar]
             [lt.util.dom :as dom]
             [lt.util.cljs :as cljs]
             [lt.objs.workspace :as workspace]
@@ -116,7 +116,7 @@
 
 (def container (object/create ::container))
 
-(statusbar/add-statusbar-item container)
+(statusbar/add-status-item container)
 
 ;; Container
 ;;


### PR DESCRIPTION
Not advocating for applying this patch currently, and I'm not familiar enough with ClosureScript (yet) to suggest how to deal with both variants of the API at this stage.  Just a heads up that I was working against LightTable master and this and the syntax status bar plugin wouldn't load due to these API changes...
